### PR TITLE
fix: permitir actualización de configuración de horas extra sin campo…

### DIFF
--- a/ExtraHours.API/Model/ExtraHoursConfig.cs
+++ b/ExtraHours.API/Model/ExtraHoursConfig.cs
@@ -14,21 +14,21 @@ namespace ExtraHours.API.Model
         [Column("weeklyExtraHoursLimit")]
         public double weeklyExtraHoursLimit { get; set; }
 
-        [Required]
-        [Column("diurnalMultiplier")]
-        public double diurnalMultiplier { get; set; }
+        // [Required]
+        // [Column("diurnalMultiplier")]
+        // public double diurnalMultiplier { get; set; }
 
-        [Required]
-        [Column("nocturnalMultiplier")]
-        public double nocturnalMultiplier { get; set; }
+        // [Required]
+        // [Column("nocturnalMultiplier")]
+        // public double nocturnalMultiplier { get; set; }
 
-        [Required]
-        [Column("diurnalHolidayMultiplier")]
-        public double diurnalHolidayMultiplier { get; set; }
+        // [Required]
+        // [Column("diurnalHolidayMultiplier")]
+        // public double diurnalHolidayMultiplier { get; set; }
 
-        [Required]
-        [Column("nocturnalHolidayMultiplier")]
-        public double nocturnalHolidayMultiplier { get; set; }
+        // [Required]
+        // [Column("nocturnalHolidayMultiplier")]
+        // public double nocturnalHolidayMultiplier { get; set; }
 
         [Required]
         [Column("diurnalStart", TypeName = "time")]


### PR DESCRIPTION
…s de multiplicadores. Se comentaron los campos diurnalMultiplier, nocturnalMultiplier, diurnalHolidayMultiplier y nocturnalHolidayMultiplier en el modelo ExtraHoursConfig para que el backend acepte correctamente los datos enviados por el frontend.